### PR TITLE
Update python_version for 3.13

### DIFF
--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,2 +1,3 @@
 **Unreleased**
 * Resolved app issues related to Python 3.13 upgrade
+* Update Python version for 3.13

--- a/unshortenme.json
+++ b/unshortenme.json
@@ -12,7 +12,7 @@
     "product_name": "Unshorten.me",
     "product_version_regex": ".*",
     "min_phantom_version": "4.9.39220",
-    "python_version": "3",
+    "python_version": ["3.9", "3.13"],
     "fips_compliant": true,
     "latest_tested_versions": [
         "Cloud, Tested on 16th July, 2021"


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13

[_Created by Sourcegraph batch change `grokas-splunk/002-update-python-versions-3.13`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/002-update-python-versions-3.13)