### PR TITLE
fix: handle unexpected JSON response shapes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,13 +27,13 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.22
+    rev: v0.16.1
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.42.1
+    rev: v1.43.2
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.2.8
+    rev: v2.2.9
     hooks:
       - id: build-docs
         language: python

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Handle unexpected non-object JSON responses as connector errors instead of unhandled exceptions.

--- a/unshortenme_connector.py
+++ b/unshortenme_connector.py
@@ -67,6 +67,10 @@ class UnshortenmeConnector(BaseConnector):
             message = f"Error response from server. Status code: {res.status_code}Response: \n{error_text}\n"
             return action_result.set_status(phantom.APP_ERROR, message), None
 
+        if not isinstance(data, dict):
+            message = f"Unexpected non-object JSON response from server (type: {type(data).__name__})"
+            return action_result.set_status(phantom.APP_ERROR, message), None
+
         if "error" in data:
             message = "API returned error: {}".format(data["error"])
             return action_result.set_status(phantom.APP_ERROR, message), data


### PR DESCRIPTION
### Bug Fixes

- Return `APP_ERROR` when a successful unshorten.me response parses as non-object JSON, before the existing dictionary operations can raise an unhandled exception.

### Manual Documentation

- [x] I have verified that manual documentation has been updated where appropriate. No manual documentation change is needed for this response-validation fix.

### Other information

Written by Codex.

#### Tracking

- Campaign epic: ESPM-5228
- PAPP: PAPP-38325
- PSAAS: PSAAS-35081
- Provenance: VULN-103702, FS-8635
- Target: `splunk-soar-connectors/unshortenme:main`

#### Source and patch review

- The [official unshorten.me API documentation](https://unshorten.me/api) documents object-shaped JSON responses.
- The [current connector response path](https://github.com/splunk-soar-connectors/unshortenme/blob/5bfe0f7add9e5f54a2ca291cefef5e3493f33a7a/unshortenme_connector.py#L45-L75) performs dictionary operations immediately after JSON parsing.
- Patch deviations: no behavioral deviation from the suggested type guard. The patch was adapted to current `main` formatting and placed immediately before dictionary access; the suggested broad defense-in-depth exception wrapper was intentionally not added.

#### Verification

- `pre-commit install`
- `pre-commit autoupdate`
- `pre-commit run --all-files` passed, including Docker-backed packaging, SOAR app lint, Semgrep, release-note validation, and static tests.
- `/opt/homebrew/bin/python3.13 -m py_compile unshortenme_connector.py` passed.
- This is a legacy `BaseConnector` app, so no SDK pytest suite or connector-local fake tests were added.

#### Compatibility

- Breaking changes: none. This adds structural response validation without changing action parameters, outputs, asset configuration, defaults, versions, or `min_phantom_version`.
- One user-visible fix commit has one matching single-sentence unreleased note.

Merge strategy: merge commit only; do not squash.

---
Please refer to our [Contribution Guide](https://github.com/splunk-soar-connectors/.github/blob/main/.github/CONTRIBUTING.md) for any questions on submitting a pull request.

Thanks for contributing!